### PR TITLE
Feature/main page creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,14 @@ import LoginPage from './components/Login/LoginPage';
 import Header from './components/Header/Header';
 import UserSignupPage from './components/Signup/UserSignupPage';
 import MainPage from './components/MainPage/MainPage';
+import NightmareDetail from './components/MainPage/NightmareDetail';
 import { login } from './store/slices/authSlice';
 
 const routes = [
   { path: '/placeholder', element: <PlaceholderPage /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/signup', element: <UserSignupPage /> },
+  { path: '/nightmares/:id', element: <NightmareDetail /> },
   { path: '/mainPage', element: <MainPage /> },
 ];
 
@@ -27,12 +29,14 @@ function App() {
 
   return (
     <Router>
-      <Header />
-      <Routes>
-        {routes.map((route, index) => (
-          <Route key={index} path={route.path} element={route.element} />
-        ))}
-      </Routes>
+      <div className="bg-gray-100 min-h-screen">
+        <Header />
+        <Routes>
+          {routes.map((route, index) => (
+            <Route key={index} path={route.path} element={route.element} />
+          ))}
+        </Routes>
+      </div>
     </Router>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,14 @@ import PlaceholderPage from './PlaceholderPage';
 import LoginPage from './components/Login/LoginPage';
 import Header from './components/Header/Header';
 import UserSignupPage from './components/Signup/UserSignupPage';
+import MainPage from './components/MainPage/MainPage';
 import { login } from './store/slices/authSlice';
 
 const routes = [
   { path: '/placeholder', element: <PlaceholderPage /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/signup', element: <UserSignupPage /> },
-  // 他のルートもここに追加できる
+  { path: '/mainPage', element: <MainPage /> },
 ];
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,13 @@ import Header from './components/Header/Header';
 import UserSignupPage from './components/Signup/UserSignupPage';
 import { login } from './store/slices/authSlice';
 
+const routes = [
+  { path: '/placeholder', element: <PlaceholderPage /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/signup', element: <UserSignupPage /> },
+  // 他のルートもここに追加できる
+];
+
 function App() {
   const dispatch = useDispatch();
 
@@ -21,9 +28,9 @@ function App() {
     <Router>
       <Header />
       <Routes>
-        <Route path="/placeholder" element={<PlaceholderPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/signup" element={<UserSignupPage />} />
+        {routes.map((route, index) => (
+          <Route key={index} path={route.path} element={route.element} />
+        ))}
       </Routes>
     </Router>
   );

--- a/src/components/Login/LoginPage.tsx
+++ b/src/components/Login/LoginPage.tsx
@@ -34,7 +34,7 @@ const LoginPage = () => {
         console.log('Login successful:', data);
         localStorage.setItem('authToken', data.token); // トークンをローカルストレージに保存
         dispatch(login());  // ログイン状態を更新
-        navigate('/placeholder'); // 仮のトップページに遷移
+        navigate('/mainPage'); // 仮のトップページに遷移
       } else {
         console.error('Login failed:', data);
       }

--- a/src/components/MainPage/MainPage.tsx
+++ b/src/components/MainPage/MainPage.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import PostCard from './PostCard/PostCard';
+
+interface Post {
+  title: string;
+  content: string;
+  author: string;
+}
+
+const MainPage: React.FC = () => {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/posts`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch posts');
+        }
+        const data = await response.json();
+        setPosts(data);
+      } catch (error: any) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  return (
+    <div className="main-page">
+      <header className="main-header">
+        <h1>Welcome to the Main Page</h1>
+      </header>
+      <main className="main-content">
+        {posts.map((post, index) => (
+          <PostCard key={index} title={post.title} content={post.content} author={post.author} />
+        ))}
+      </main>
+      <footer className="main-footer">
+        {/* Footer content goes here */}
+      </footer>
+    </div>
+  );
+};
+
+export default MainPage;

--- a/src/components/MainPage/MainPage.tsx
+++ b/src/components/MainPage/MainPage.tsx
@@ -1,58 +1,61 @@
 import React, { useEffect, useState } from 'react';
 import PostCard from './PostCard/PostCard';
 
-interface Post {
-  title: string;
-  content: string;
+interface Nightmare {
+  description: string;
+  modified_description: string;
   author: string;
 }
 
 const MainPage: React.FC = () => {
-  const [posts, setPosts] = useState<Post[]>([]);
+  const [nightmares, setNightmares] = useState<Nightmare[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchPosts = async () => {
+    const fetchNightmares = async () => {
       const token = localStorage.getItem('authToken'); // ローカルストレージからトークンを取得
       console.log('Token:', token);
       try {
-        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/posts`, {
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/nightmares`, {
           headers: {
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${token}` // 認証トークンをヘッダーに追加
           }
         });
         if (!response.ok) {
-          throw new Error('Failed to fetch posts');
+          throw new Error('Failed to fetch nightmares');
         }
         const data = await response.json();
-        setPosts(data);
+        setNightmares(data);
       } catch (error: any) {
         setError(error.message);
       } finally {
         setLoading(false);
       }
     };
-    fetchPosts();
+    fetchNightmares();
   }, []);  
 
   if (loading) {
     return <div>Loading...</div>;
   }
-
   if (error) {
     return <div>Error: {error}</div>;
   }
-
   return (
     <div className="main-page">
       <header className="main-header">
         <h1>Welcome to the Main Page</h1>
       </header>
       <main className="main-content">
-        {posts.map((post, index) => (
-          <PostCard key={index} title={post.title} content={post.content} author={post.author} />
+        {nightmares.map((nightmare, index) => (
+          <PostCard
+            key={index}
+            title={nightmare.description}
+            content={nightmare.modified_description}
+            author={nightmare.author}
+          />
         ))}
       </main>
       <footer className="main-footer">

--- a/src/components/MainPage/MainPage.tsx
+++ b/src/components/MainPage/MainPage.tsx
@@ -61,12 +61,12 @@ const MainPage: React.FC = () => {
         <header className="main-header text-center mb-6">
           <h1 className="text-2xl font-bold">救済された悪夢たち</h1>
         </header>
-        <main className="flex flex-wrap justify-between px-[20px] py-[10px]"> {/* bg-blue-100を削除 */}
+        <main className="grid grid-cols-3 gap-4"> {/* 3列に設定 */}
           {currentNightmares.map((nightmare) => (
             <Link key={nightmare.id} to={`/nightmares/${nightmare.id}`}>
               <PostCard
-                title={nightmare.description.length > 50 ? nightmare.description.substring(0, 50) + '...' : nightmare.description}
-                content={nightmare.modified_description}
+                description={nightmare.description.length > 50 ? nightmare.description.substring(0, 50) + '...' : nightmare.description}
+                modified_description={nightmare.modified_description}
                 author={nightmare.author}
               />
             </Link>
@@ -85,7 +85,7 @@ const MainPage: React.FC = () => {
         </nav>
       </div>
     </div>
-  );    
+  );
 };
 
 export default MainPage;

--- a/src/components/MainPage/MainPage.tsx
+++ b/src/components/MainPage/MainPage.tsx
@@ -14,8 +14,15 @@ const MainPage: React.FC = () => {
 
   useEffect(() => {
     const fetchPosts = async () => {
+      const token = localStorage.getItem('authToken'); // ローカルストレージからトークンを取得
+      console.log('Token:', token);
       try {
-        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/posts`);
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/posts`, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}` // 認証トークンをヘッダーに追加
+          }
+        });
         if (!response.ok) {
           throw new Error('Failed to fetch posts');
         }
@@ -27,9 +34,8 @@ const MainPage: React.FC = () => {
         setLoading(false);
       }
     };
-
     fetchPosts();
-  }, []);
+  }, []);  
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/components/MainPage/NightmareDetail.tsx
+++ b/src/components/MainPage/NightmareDetail.tsx
@@ -50,10 +50,14 @@ const NightmareDetail: React.FC = () => {
   }
 
   return (
-    <div className="nightmare-detail">
-      <h1>{nightmare.description}</h1>
-      <p>{nightmare.modified_description}</p>
-      <p>{nightmare.author}</p>
+    <div className="nightmare-detail flex flex-col justify-center items-center mt-8">
+      <div className="bg-white shadow-lg rounded-lg p-6 max-w-2xl w-full">
+        <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">{nightmare.author}さんの悪夢</h1>
+        <h3 className="text-lg font-semibold mb-2">悪夢内容：</h3>
+        <p className="border-l-4 border-rose-400 pl-4 text-gray-700 text-base md:text-lg lg:text-xl mb-2 break-words">{nightmare.description}</p>
+        <h3 className="text-lg font-semibold mb-2">改変された結末：</h3>
+        <p className="border-l-4 border-indigo-400 pl-4 text-gray-700 text-base md:text-lg lg:text-xl mb-2 break-words">{nightmare.modified_description}</p>
+      </div>
       <Link to="/mainPage" className="block text-center mt-6 text-blue-600 hover:text-blue-400 text-lg md:text-xl">
         一覧へ戻る
       </Link>

--- a/src/components/MainPage/NightmareDetail.tsx
+++ b/src/components/MainPage/NightmareDetail.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+
+interface Nightmare {
+  id: number;
+  description: string;
+  modified_description: string;
+  author: string;
+}
+
+const NightmareDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [nightmare, setNightmare] = useState<Nightmare | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchNightmare = async () => {
+      const token = localStorage.getItem('authToken');
+      try {
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/nightmares/${id}`, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          }
+        });
+        if (!response.ok) {
+          throw new Error('Failed to fetch nightmare');
+        }
+        const data = await response.json();
+        setNightmare(data);
+      } catch (error: any) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchNightmare();
+  }, [id]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+  if (!nightmare) {
+    return <div>No nightmare found</div>;
+  }
+
+  return (
+    <div className="nightmare-detail">
+      <h1>{nightmare.description}</h1>
+      <p>{nightmare.modified_description}</p>
+      <p>{nightmare.author}</p>
+      <Link to="/mainPage" className="block text-center mt-6 text-blue-600 hover:text-blue-400 text-lg md:text-xl">
+        一覧へ戻る
+      </Link>
+    </div>
+  );
+};
+
+export default NightmareDetail;

--- a/src/components/MainPage/PostCard/PostCard.tsx
+++ b/src/components/MainPage/PostCard/PostCard.tsx
@@ -8,7 +8,7 @@ interface PostCardProps {
 
 const PostCard: React.FC<PostCardProps> = ({ title, content, author }) => {
   return (
-    <div className="post-card p-4 mb-4 border rounded shadow">
+    <div className="post-card p-4 mb-4 border border-gray-300 rounded shadow-lg bg-blue-50"> {/* カードを薄い青に設定 */}
       <h2 className="text-xl font-bold mb-2">{title}</h2>
       <p className="text-gray-700 mb-4">{content}</p>
       <p className="text-gray-500 text-right">- {author}</p>

--- a/src/components/MainPage/PostCard/PostCard.tsx
+++ b/src/components/MainPage/PostCard/PostCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface PostCardProps {
+  title: string;
+  content: string;
+  author: string;
+}
+
+const PostCard: React.FC<PostCardProps> = ({ title, content, author }) => {
+  return (
+    <div className="post-card p-4 mb-4 border rounded shadow">
+      <h2 className="text-xl font-bold mb-2">{title}</h2>
+      <p className="text-gray-700 mb-4">{content}</p>
+      <p className="text-gray-500 text-right">- {author}</p>
+    </div>
+  );
+};
+
+export default PostCard;

--- a/src/components/MainPage/PostCard/PostCard.tsx
+++ b/src/components/MainPage/PostCard/PostCard.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
 interface PostCardProps {
-  title: string;
-  content: string;
+  description: string;
+  modified_description: string;
   author: string;
 }
 
-const PostCard: React.FC<PostCardProps> = ({ title, content, author }) => {
+const PostCard: React.FC<PostCardProps> = ({ description, modified_description, author }) => {
   return (
-    <div className="post-card p-4 mb-4 border border-gray-300 rounded shadow-lg bg-blue-50"> {/* カードを薄い青に設定 */}
-      <h2 className="text-xl font-bold mb-2">{title}</h2>
-      <p className="text-gray-700 mb-4">{content}</p>
+    <div className="post-card p-4 mb-4 border rounded shadow-lg bg-blue-100 h-64"> {/* カードの高さを大きめに設定 */}
+      <h2 className="text-xl font-bold mb-2 break-words">{description.length > 50 ? description.slice(0, 50) + '...' : description}</h2>
+      <p className="text-gray-700 mb-4 break-words">{modified_description.length > 50 ? modified_description.slice(0, 50) + '...' : modified_description}</p>
       <p className="text-gray-500 text-right">- {author}</p>
     </div>
   );

--- a/src/components/MainPage/PostCard/PostCard.tsx
+++ b/src/components/MainPage/PostCard/PostCard.tsx
@@ -8,10 +8,12 @@ interface PostCardProps {
 
 const PostCard: React.FC<PostCardProps> = ({ description, modified_description, author }) => {
   return (
-    <div className="post-card p-4 mb-4 border rounded shadow-lg bg-blue-100 h-64"> {/* カードの高さを大きめに設定 */}
-      <h2 className="text-xl font-bold mb-2 break-words">{description.length > 50 ? description.slice(0, 50) + '...' : description}</h2>
-      <p className="text-gray-700 mb-4 break-words">{modified_description.length > 50 ? modified_description.slice(0, 50) + '...' : modified_description}</p>
-      <p className="text-gray-500 text-right">- {author}</p>
+    <div className="post-card p-4 mb-4 border rounded-xl shadow-lg bg-white h-full">
+      <h3 className="text-2xl md:text-3xl lg:text-2xl font-semibold text-center mb-4">{author}さんの悪夢</h3>
+      <h3 className="text-lg font-semibold mb-1">悪夢内容：</h3>
+      <p className="border-l-4 border-rose-300 pl-4 text-left mb-4 break-words">{description.length > 50 ? description.slice(0, 50) + '...' : description}</p>
+      <h3 className="text-lg font-semibold mb-1">改変された結末：</h3>
+      <p className="border-l-4 border-indigo-300 pl-4 text-gray-700 mb-4 break-words">{modified_description.length > 50 ? modified_description.slice(0, 50) + '...' : modified_description}</p>
     </div>
   );
 };


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/users/tokaisagami/projects/1/views/1?pane=issue&itemId=81420297&issue=tokaisagami%7Cnightmare-app%7C19

## やったこと

* ログイン画面修正
  * ログイン後遷移先変更（仮のTOPページ ⇒ メインページ）
  * 

* メインページ画面の追加
  * App.tsxにコンポーネント追加
  * ページネーション実装
  * 投稿内容（author：投稿者名、description：悪夢内容、modified_description：改変された悪夢内容）をカード形式で表示
  * 投稿カードクリックで詳細ページへ遷移
  * ローカルストレージからトークンを取得
  * 認証トークンをヘッダーに追加

* 投稿内容カードの追加
  * 投稿内容を50字制限付きで表示

* 詳細ページ画面の追加
  * 投稿内容をフルで表示
  * メインページへのリンク設定
  *  認証トークンをヘッダーに追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 投稿内容の閲覧

## できなくなること（ユーザ目線）

* 仮のTOPページへの遷移

## 動作確認

* 開発環境にて、API側のpostgresqlDB（nightmares）にデータ（投稿内容）を手動で投入し、画面側から閲覧できることを確認。
* Dockerログを確認し、ERRORが発生していないことを確認。

## その他

* なし