### PR TITLE
アカウント設定＆投稿内容削除＆パスワードリセット実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import InputNightmare from './components/MainPage/InputNightmare';
 import DisplayNightmare from './components/MainPage/DisplayNightmare';
 import HomePage from './components/HomePage/HomePage';
 import MyPage from './components/MyPage/MyPage';
+import AccountSettings from './components/AccountSettings/AccountSettings';
 import { login } from './store/slices/authSlice';
 import { startLoading, stopLoading } from './store/slices/loadingSlice'; // ローディングアクションのインポート
 import { RootState } from './store/store'; // RootStateをインポート
@@ -25,6 +26,7 @@ const routes = [
   { path: '/input-nightmare', element: <InputNightmare /> },
   { path: '/modified-nightmare', element: <DisplayNightmare /> },
   { path: '/mypage', element: <MyPage /> },
+  { path: '/account-settings', element: <AccountSettings /> }, // 新しいルートの追加
 ];
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import DisplayNightmare from './components/MainPage/DisplayNightmare';
 import HomePage from './components/HomePage/HomePage';
 import MyPage from './components/MyPage/MyPage';
 import AccountSettings from './components/AccountSettings/AccountSettings';
+import PasswordResetRequest from './components/PasswordResetRequest/PasswordResetRequest';
 import { login } from './store/slices/authSlice';
 import { startLoading, stopLoading } from './store/slices/loadingSlice'; // ローディングアクションのインポート
 import { RootState } from './store/store'; // RootStateをインポート
@@ -27,6 +28,7 @@ const routes = [
   { path: '/modified-nightmare', element: <DisplayNightmare /> },
   { path: '/mypage', element: <MyPage /> },
   { path: '/account-settings', element: <AccountSettings /> }, // 新しいルートの追加
+  { path: '/password-reset-request', element: <PasswordResetRequest /> }, // 新しいルートの追加
 ];
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import HomePage from './components/HomePage/HomePage';
 import MyPage from './components/MyPage/MyPage';
 import AccountSettings from './components/AccountSettings/AccountSettings';
 import PasswordResetRequest from './components/PasswordResetRequest/PasswordResetRequest';
+import PasswordReset from './components/PasswordReset/PasswordReset';
 import { login } from './store/slices/authSlice';
 import { startLoading, stopLoading } from './store/slices/loadingSlice'; // ローディングアクションのインポート
 import { RootState } from './store/store'; // RootStateをインポート
@@ -29,6 +30,7 @@ const routes = [
   { path: '/mypage', element: <MyPage /> },
   { path: '/account-settings', element: <AccountSettings /> }, // 新しいルートの追加
   { path: '/password-reset-request', element: <PasswordResetRequest /> }, // 新しいルートの追加
+  { path: '/password-reset', element: <PasswordReset /> }, // 新しいルートの追加
 ];
 
 function App() {

--- a/src/components/AccountSettings/AccountSettings.tsx
+++ b/src/components/AccountSettings/AccountSettings.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../store/store';
+import { updateUser } from '../../store/slices/authSlice'; // 更新アクションをインポート
+
+const AccountSettings: React.FC = () => {
+  const user = useSelector((state: RootState) => state.auth.user);
+  const dispatch = useDispatch();
+  const [name, setName] = useState(user?.name || '');
+  const [email, setEmail] = useState(user?.email || '');
+
+  const handleSave = async () => {
+    if (user?.id) {
+      try {
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/users/${user.id}`, {
+          method: 'PUT',
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ name, email }),
+        });
+
+        if (response.ok) {
+          const updatedUser = await response.json();
+          dispatch(updateUser(updatedUser)); // ユーザー情報を更新
+          alert('アカウント情報が更新されました');
+        } else {
+          console.error('Failed to update user');
+          alert('アカウント情報の更新に失敗しました');
+        }
+      } catch (error) {
+        console.error('Error updating user:', error);
+        alert('アカウント情報の更新中にエラーが発生しました');
+      }
+    }
+  };
+
+  return (
+    <div className="account-settings flex flex-col justify-center items-center mt-8 px-4 md:px-8 w-full">
+      <div className="bg-white shadow-lg rounded-lg p-6 max-w-2xl w-full mx-auto">
+        <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">アカウント設定</h1>
+        <div className="mb-4">
+          <label className="block text-lg mb-2">ユーザー名</label>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-lg mb-2">メールアドレス</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+        </div>
+        <button
+          onClick={handleSave}
+          className="mt-4 bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          保存
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AccountSettings;

--- a/src/components/AccountSettings/AccountSettings.tsx
+++ b/src/components/AccountSettings/AccountSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import { updateUser } from '../../store/slices/authSlice'; // 更新アクションをインポート
+import { Link } from 'react-router-dom';
 
 const AccountSettings: React.FC = () => {
   const user = useSelector((state: RootState) => state.auth.user);
@@ -65,6 +66,10 @@ const AccountSettings: React.FC = () => {
           >
             保存
           </button>
+          {/* パスワードリセット申請画面へのリンク */}
+          <Link to="/password-reset-request" className="text-blue-500 hover:text-blue-700 font-KosugiMaru text-center">
+            パスワードリセット申請はこちら
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/AccountSettings/AccountSettings.tsx
+++ b/src/components/AccountSettings/AccountSettings.tsx
@@ -37,11 +37,11 @@ const AccountSettings: React.FC = () => {
   };
 
   return (
-    <div className="account-settings flex flex-col justify-center items-center mt-8 px-4 md:px-8 w-full">
-      <div className="bg-white shadow-lg rounded-lg p-6 max-w-2xl w-full mx-auto">
-        <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">アカウント設定</h1>
+    <div className="flex justify-center items-center min-h-screen bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-md border border-gray-300 w-full max-w-md">
+        <h1 className="text-2xl md:text-3xl lg:text-4xl font-KaiseiOpti text-center mb-4">アカウント設定</h1>
         <div className="mb-4">
-          <label className="block text-lg mb-2">ユーザー名</label>
+          <label className="block text-lg font-KaiseiOpti mb-2">ユーザー名</label>
           <input
             type="text"
             value={name}
@@ -50,7 +50,7 @@ const AccountSettings: React.FC = () => {
           />
         </div>
         <div className="mb-4">
-          <label className="block text-lg mb-2">メールアドレス</label>
+          <label className="block text-lg font-KaiseiOpti mb-2">メールアドレス</label>
           <input
             type="email"
             value={email}
@@ -58,12 +58,14 @@ const AccountSettings: React.FC = () => {
             className="w-full px-3 py-2 border rounded"
           />
         </div>
-        <button
-          onClick={handleSave}
-          className="mt-4 bg-blue-500 text-white px-4 py-2 rounded"
-        >
-          保存
-        </button>
+        <div className="flex flex-col space-y-4 items-center">
+          <button
+            onClick={handleSave}
+            className="w-1/4 bg-blue-500 hover:bg-blue-600 text-white font-KosugiMaru px-4 py-2 rounded"
+          >
+            保存
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/MyPage/MyPage.tsx
+++ b/src/components/MyPage/MyPage.tsx
@@ -99,6 +99,9 @@ const MyPage: React.FC = () => {
         <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">マイページ</h1>
         <p className="text-lg md:text-xl lg:text-2xl mb-2">ユーザー名: {user?.name}</p>
         <p className="text-lg md:text-xl lg:text-2xl mb-2">メール: {user?.email}</p>
+        <div className="mt-4 text-center">
+          <Link to="/account-settings" className="text-blue-500 hover:text-blue-700 font-KosugiMaru">アカウント設定へ</Link> {/* 新しいリンクの追加 */}
+        </div>
         <div>
           <h2 className="text-xl mt-4 mb-2">投稿した悪夢内容：</h2>
           {loading ? (

--- a/src/components/MyPage/MyPage.tsx
+++ b/src/components/MyPage/MyPage.tsx
@@ -18,7 +18,6 @@ const MyPage: React.FC = () => {
   const [nightmares, setNightmares] = useState<Nightmare[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // useEffect以降の部分
   useEffect(() => {
     if (user?.id) {
       const fetchNightmares = async () => {
@@ -42,7 +41,6 @@ const MyPage: React.FC = () => {
     }
   }, [user?.id]);
 
-  // 非公開にする関数を追加
   const handleUnpublish = async (nightmareId: number) => {
     try {
       const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/nightmares/${nightmareId}`, {
@@ -89,6 +87,29 @@ const MyPage: React.FC = () => {
     }
   };
 
+  // 修正: 削除機能
+  const handleDelete = async (nightmareId: number) => {
+    if (window.confirm("本当にこの悪夢を削除しますか？")) {
+      try {
+        const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/nightmares/${nightmareId}`, {
+          method: 'DELETE',
+          headers: {
+            'Authorization': `Bearer ${localStorage.getItem('authToken')}`,
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (response.ok) {
+          setNightmares(nightmares.filter(nightmare => nightmare.id !== nightmareId));
+        } else {
+          console.error('Failed to delete nightmare');
+        }
+      } catch (error) {
+        console.error('Error deleting nightmare:', error);
+      }
+    }
+  };
+
   if (!user) {
     return <Loading />;
   }
@@ -129,18 +150,25 @@ const MyPage: React.FC = () => {
                     {nightmare.published ? (
                       <button
                         onClick={() => handleUnpublish(nightmare.id)}
-                        className="mt-2 bg-red-500 text-white font-KosugiMaru px-4 py-2 rounded"
+                        className="mt-2 bg-red-500 text-white font-KosugiMaru px-4 py-2 rounded mr-2"
                       >
                         非公開にする
                       </button>
                     ) : (
                       <button
                         onClick={() => handlePublish(nightmare.id)}
-                        className="mt-2 bg-green-500 text-white font-KosugiMaru px-4 py-2 rounded"
+                        className="mt-2 bg-green-500 text-white font-KosugiMaru px-4 py-2 rounded mr-2"
                       >
                         公開にする
                       </button>
                     )}
+                    {/* 修正: 削除ボタン */}
+                    <button
+                      onClick={() => handleDelete(nightmare.id)}
+                      className="mt-2 bg-gray-500 text-white font-KosugiMaru px-4 py-2 rounded"
+                    >
+                      削除
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/src/components/MyPage/MyPage.tsx
+++ b/src/components/MyPage/MyPage.tsx
@@ -114,17 +114,22 @@ const MyPage: React.FC = () => {
     return <Loading />;
   }
 
+  // レスポンシブ対応のためにCSSクラスを修正
   return (
-    <div className="mypage flex flex-col justify-center items-center mt-8 px-4 md:px-8 w-full">
-      <div className="bg-white shadow-lg rounded-lg p-6 max-w-2xl w-full mx-auto">
-        <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">マイページ</h1>
-        <p className="text-lg md:text-xl lg:text-2xl mb-2">ユーザー名: {user?.name}</p>
-        <p className="text-lg md:text-xl lg:text-2xl mb-2">メール: {user?.email}</p>
-        <div className="mt-4 text-center">
-          <Link to="/account-settings" className="text-blue-500 hover:text-blue-700 font-KosugiMaru">アカウント設定へ</Link> {/* 新しいリンクの追加 */}
+    <div className="mypage flex flex-col items-center mt-8 px-4 md:px-8 w-full">
+      <h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-4">マイページ</h1>
+      <div className="flex flex-col md:flex-row justify-between w-full max-w-6xl">
+        {/* ユーザー情報とアカウント設定の枠 */}
+        <div className="bg-white border border-gray-300 shadow-lg rounded-lg p-6 mb-4 md:mb-0 md:mr-4 w-full md:w-1/3" style={{ maxHeight: '200px' }}>
+          <p className="text-lg md:text-xl lg:text-lg mb-2">ユーザー名: {user?.name}</p>
+          <p className="text-lg md:text-xl lg:text-lg mb-2">メール: {user?.email}</p>
+          <div className="mt-4">
+            <Link to="/account-settings" className="text-blue-500 hover:text-blue-700 font-KosugiMaru">アカウント設定へ</Link>
+          </div>
         </div>
-        <div>
-          <h2 className="text-xl mt-4 mb-2">投稿した悪夢内容：</h2>
+        {/* 投稿された悪夢内容の枠 */}
+        <div className="bg-white border border-gray-300 shadow-lg rounded-lg p-6 w-full md:w-2/3 overflow-y-scroll" style={{ maxHeight: '600px' }}>
+          <h2 className="text-xl mb-2">投稿した悪夢内容：</h2>
           {loading ? (
             <p>Loading...</p>
           ) : (
@@ -133,7 +138,7 @@ const MyPage: React.FC = () => {
             ) : (
               <ul>
                 {nightmares.map(nightmare => (
-                  <li key={nightmare.id} className="mb-4">
+                  <li key={nightmare.id} className="mb-4 bg-gray-100 p-4 rounded-lg shadow-md">
                     <h3 className="text-lg font-semibold">{nightmare.description}</h3>
                     <p className="text-sm text-gray-600">{nightmare.modified_description}</p>
                     <p className="text-sm">
@@ -162,7 +167,6 @@ const MyPage: React.FC = () => {
                         公開にする
                       </button>
                     )}
-                    {/* 修正: 削除ボタン */}
                     <button
                       onClick={() => handleDelete(nightmare.id)}
                       className="mt-2 bg-gray-500 text-white font-KosugiMaru px-4 py-2 rounded"
@@ -174,9 +178,6 @@ const MyPage: React.FC = () => {
               </ul>
             )
           )}
-        </div>
-        <div className="mt-4 text-center">
-          <Link to="/mainPage" className="text-blue-500 hover:text-blue-700 font-KosugiMaru">メインページへ</Link>
         </div>
       </div>
     </div>

--- a/src/components/PasswordReset/PasswordReset.tsx
+++ b/src/components/PasswordReset/PasswordReset.tsx
@@ -1,5 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
+import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core'
+import { ZxcvbnResult } from '@zxcvbn-ts/core/src/types'
+import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
+import * as zxcvbnJaPackage from '@zxcvbn-ts/language-ja'
 
 const PasswordReset: React.FC = () => {
   const navigate = useNavigate();
@@ -10,6 +16,9 @@ const PasswordReset: React.FC = () => {
 
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [result, setResult] = useState<ZxcvbnResult | undefined>(undefined);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirmation, setShowPasswordConfirmation] = useState(false);
 
   const handleReset = async () => {
     if (newPassword !== confirmPassword) {
@@ -23,7 +32,7 @@ const PasswordReset: React.FC = () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ email, password: newPassword }),
+        body: JSON.stringify({ password_reset: { password: newPassword, password_confirmation: confirmPassword } }),
       });
 
       if (response.ok) {
@@ -38,28 +47,100 @@ const PasswordReset: React.FC = () => {
     }
   };
 
+  // zxcvbnの設定
+  const options = {
+    translations: zxcvbnJaPackage.translations,
+    graphs: zxcvbnCommonPackage.adjacencyGraphs,
+    dictionary: {
+      ...zxcvbnCommonPackage.dictionary,
+      ...zxcvbnJaPackage.dictionary,
+    },
+  }
+  zxcvbnOptions.setOptions(options)
+
+  useEffect(() => {
+    // パスワードがない場合はzxcvbnの結果をリセットする
+    if (!newPassword) {
+      setResult(undefined);
+      return;
+    }
+    // 入力されたパスワードを用いてzxcvbnの結果を取得、useStateに格納する
+    const newResult = zxcvbn(newPassword);
+    setResult(newResult);
+  }, [newPassword]);
+
+  const getBarColor = (v: number, score: number) => {
+    if (v <= score) {
+      switch (score) {
+        case 0:
+          return 'bg-red-500';
+        case 1:
+          return 'bg-orange-500';
+        case 2:
+          return 'bg-yellow-500';
+        case 3:
+          return 'bg-green-500';
+        case 4:
+          return 'bg-blue-500';
+        default:
+          return 'bg-gray-500';
+      }
+    }
+    return 'bg-gray-300';
+  };
+
   return (
     <div className="flex justify-center items-center min-h-screen bg-gray-50">
       <div className="bg-white p-8 rounded-lg shadow-md border border-gray-300 w-full max-w-md">
         <h1 className="text-2xl md:text-3xl lg:text-4xl font-KaiseiOpti text-center mb-4">パスワードリセット</h1>
         <p className="text-lg mb-4">メールアドレス: {email}</p>
-        <div className="mb-4">
+        <div className="mb-4 relative">
           <label className="block text-lg font-KaiseiOpti mb-2">新しいパスワード</label>
-          <input
-            type="password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            className="w-full px-3 py-2 border rounded"
-          />
+          <div className="relative">
+            <input
+              type={showPassword ? "text" : "password"}
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full px-3 py-2 border rounded"
+            />
+            <span
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer opacity-50 hover:opacity-100"
+            >
+              <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />
+            </span>
+          </div>
+          <div className="mt-[20px]">
+            <div className="flex w-full gap-[1%]">
+              {/* 強度を表す5段階のバーを表示 */}
+              {[0, 1, 2, 3, 4].map((v) => (
+                <div
+                  className={`h-[4px] w-[24%] ${result ? getBarColor(v, result.score) : 'bg-gray-300'}`}
+                  key={v}
+                />
+              ))}
+            </div>
+            {result && result.score + 1}
+          </div>
+          {/* feedback.warning がある場合は表示 */}
+          {result?.feedback && <div className="text-[#f00]">{result.feedback.warning}</div>}
         </div>
-        <div className="mb-4">
+        <div className="mb-4 relative">
           <label className="block text-lg font-KaiseiOpti mb-2">新しいパスワード（確認用）</label>
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            className="w-full px-3 py-2 border rounded"
-          />
+          <div className="relative">
+            <input
+              type={showPasswordConfirmation ? "text" : "password"}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 border rounded"
+            />
+            <span
+              onClick={() => setShowPasswordConfirmation(!showPasswordConfirmation)}
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer opacity-50 hover:opacity-100"
+            >
+              <FontAwesomeIcon icon={showPasswordConfirmation ? faEyeSlash : faEye} />
+            </span>
+          </div>
         </div>
         <div className="flex justify-center">
           <button

--- a/src/components/PasswordReset/PasswordReset.tsx
+++ b/src/components/PasswordReset/PasswordReset.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const PasswordReset: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const email = query.get('email') || '';
+  const token = query.get('token') || '';
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const handleReset = async () => {
+    if (newPassword !== confirmPassword) {
+      alert('パスワードが一致しません。');
+      return;
+    }
+
+    try {
+      const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/password_resets/${token}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password: newPassword }),
+      });
+
+      if (response.ok) {
+        alert('パスワードを変更しました');
+        navigate('/login');
+      } else {
+        alert('パスワードのリセットに失敗しました');
+      }
+    } catch (error) {
+      console.error('Error resetting password:', error);
+      alert('パスワードのリセット中にエラーが発生しました');
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-md border border-gray-300 w-full max-w-md">
+        <h1 className="text-2xl md:text-3xl lg:text-4xl font-KaiseiOpti text-center mb-4">パスワードリセット</h1>
+        <p className="text-lg mb-4">メールアドレス: {email}</p>
+        <div className="mb-4">
+          <label className="block text-lg font-KaiseiOpti mb-2">新しいパスワード</label>
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-lg font-KaiseiOpti mb-2">新しいパスワード（確認用）</label>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+        </div>
+        <div className="flex justify-center">
+          <button
+            onClick={handleReset}
+            className="w-1/2 bg-blue-500 hover:bg-blue-600 text-white font-KosugiMaru px-4 py-2 rounded"
+          >
+            更新
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordReset;

--- a/src/components/PasswordResetRequest/PasswordResetRequest.tsx
+++ b/src/components/PasswordResetRequest/PasswordResetRequest.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+const PasswordResetRequest: React.FC = () => {
+  const [email, setEmail] = useState('');
+
+  const handleRequest = async () => {
+    try {
+      const response = await fetch(`${import.meta.env.VITE_APP_API_URL}/api/v1/password_resets`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      if (response.ok) {
+        alert('パスワードリセット手順を送信しました');
+      } else {
+        alert('パスワードリセット手順の送信に失敗しました');
+      }
+    } catch (error) {
+      console.error('Error requesting password reset:', error);
+      alert('パスワードリセット手順の送信中にエラーが発生しました');
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow-md border border-gray-300 w-full max-w-md">
+        <h1 className="text-2xl md:text-3xl lg:text-4xl font-KaiseiOpti text-center mb-4">パスワードリセット</h1>
+        <div className="mb-4">
+          <label className="block text-lg font-KaiseiOpti mb-2">メールアドレス</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border rounded"
+          />
+        </div>
+        <div className="flex">
+          <button
+            onClick={handleRequest}
+            className="w-1/4 bg-blue-500 hover:bg-blue-600 text-white font-KosugiMaru px-4 py-2 rounded"
+          >
+            送信
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordResetRequest;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -28,8 +28,15 @@ const authSlice = createSlice({
       state.isLoggedIn = false;
       state.user = null; // ログアウト時にユーザー情報をクリア
     },
+    updateUser(state, action: PayloadAction<User>) { // 追加
+      if (state.user) {
+        state.user.name = action.payload.name;
+        state.user.email = action.payload.email;
+      }
+    },
   },
 });
 
-export const { login, logout } = authSlice.actions;
+export const { login, logout, updateUser } = authSlice.actions; // updateUser を追加
 export default authSlice.reducer;
+


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/tokaisagami/nightmare-app-frontend/issues/22
* https://github.com/tokaisagami/nightmare-app-frontend/issues/23
* https://github.com/tokaisagami/nightmare-app-frontend/issues/24

## やったこと

* アカウント設定画面作成
  * ユーザー情報（ユーザー名、メールアドレス）変更フォーム実装
  * パスワードリセット申請ページへのリンク追加

* マイページ画面変更
  * 投稿内容削除ボタン追加
  * ユーザー情報と投稿内容を横並びに表示するようレイアウト変更
  * スマホ画面の場合はユーザー情報と投稿内容が縦並びになるようレスポンシブ対応実施

* パスワードリセット申請画面作成
  * パスワードリセット申請フォーム作成

* パスワードリセット画面作成
  * パスワードリセットフォーム作成
  * パスワード表示非表示機能追加
  * パスワード強度表示追加

* 認証状態管理スライス（authSlice.ts）
  * ユーザー情報の状態管理にユーザー情報更新状態を追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 自身の投稿内容を削除
* ユーザー情報（ユーザー名、メールアドレス）変更
* パスワードリセット

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 開発環境にて、画面上で投稿内容削除、ユーザー情報変更、パスワードリセットができることを確認。
* 投稿内容削除、ユーザー情報変更、パスワードリセット実施後、API側のDBをrailsコンソールから確認し、テーブルにレコードが想定通りに追加・削除・更新されていることを確認。

## その他

* なし